### PR TITLE
Add our Jekyll theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,22 @@
+title: Process code for software procurement
+
+remote_theme: publiccodenet/jekyll-theme
+
+include:
+  - "LICENSE.md"
+
+defaults:
+  -
+    scope:
+      path: '/phases/*'
+    values:
+      breadcrumbs:
+        - name: 'Phases'
+          path: '/phases/'
+      show_prev_next: true
+
+  -
+    scope:
+      path: '/'
+    values:
+      breadcrumbs: true


### PR DESCRIPTION
Same navigation as the Standard for Public Code (breadcrumbs and prev/next) is enabled but it will need changed frontmatter to work.