### PR TITLE
ingore bidnet.com in linkcheck

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -24,12 +24,14 @@ bundle exec jekyll build
 # * docs.github.com/en : blocked by github DDoS protection
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * belastingdienst.nl : regularly cries wolf with request timed out
+# * www.bidnet.com : regularly cries wolf with request timed out
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
 ,/plausible\.io\/js\/plausible\.js/\
 ,/code\.gov\/agency-compliance\/compliance\/procurement/\
-,/belastingdienst\.nl\/wps\/wcm\/connect\/bldcontenten\/belastingdienst\//
+,/belastingdienst\.nl\/wps\/wcm\/connect\/bldcontenten\/belastingdienst\//\
+,/www\.bidnet\.com\//\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
e.g.: https://github.com/publiccodenet/process-code-software-procurement/actions/runs/3870161758/jobs/6596854439

```
Checking 66 external links...
- ./_site/phases/07-vendor-interactions.html
Ran on 17 files!
  *  External link https://www.bidnet.com/ failed: got a time out (response code 0)
```