### PR TITLE
do not link-check archive.org links

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -25,6 +25,7 @@ bundle exec jekyll build
 # * plausible.io/js/plausible.js : does not serve to scripts
 # * belastingdienst.nl : regularly cries wolf with request timed out
 # * www.bidnet.com : regularly cries wolf with request timed out
+# * web.archive.org : sometimes too slow and fails from link check
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
@@ -32,6 +33,7 @@ URL_IGNORE_REGEXES="\
 ,/code\.gov\/agency-compliance\/compliance\/procurement/\
 ,/belastingdienst\.nl\/wps\/wcm\/connect\/bldcontenten\/belastingdienst\//\
 ,/www\.bidnet\.com\//\
+,/www\.archive\.org\//\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
The site is very reliable, however often slow, and this causes timeouts. It is unlikely that any one link from archive.org will vanish, if the whole service goes down, we will know about it, because it will make the news.